### PR TITLE
[wip] split context in two

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ A small library to help get you implement beautiful, responsive, and satisfying 
 
 `yarn add beautiful-skill-tree`
 
-The package exposes three components `SkillTree`, `SkillTreeGroup` and `SkillTreeGroupProvider`.You'll also need to import the style sheet from `beautiful-skill-tree/styles.css`.
+The package exposes three components `SkillTree`, `SkillTreeGroup` and `SkillProvider`.You'll also need to import the style sheet from `beautiful-skill-tree/styles.css`.
 
 The `SkillTree` is the component that takes your data and renders the tree of components.
 
 The `SkillTreeGroup` is the component that groups skill trees and will expose in the future expose various methods and properties related to the skill tree.
 
-The `SkillTreeGroupProvider` is the skill tree's context provider.
+The `SkillProvider` is the skill tree's context provider.
 
 For those that like their data typed, you can import `SkillType` from the package.
 
@@ -32,10 +32,10 @@ import 'beautiful-skill-tree/styles.css';
 
 const data: Skill[] = [];
 
-<SkillProvider appId="test-example">
+<SkillProvider>
   <SkillTreeGroup>
     {skillCount => {
-      <SkillTree title="Skill Tree" data={data} />
+      <SkillTree treeId="first-tree" title="Skill Tree" data={data} />
     }}
     </SkillTreeGroup>
 <SkillProvider>
@@ -90,7 +90,7 @@ Unfortunately there aren't any React packages that enable us developers to easil
 
 ### SkillTree
 
-#### id: `string` [*required*]
+#### treeId: `string` [*required*]
 
 #### title: `string` [*required*]
 
@@ -101,8 +101,6 @@ Unfortunately there aren't any React packages that enable us developers to easil
 #### children: `(treeData) => React.ReactNode` [*required*]
 
 ### SkillProvider
-
-#### appId: `string` [*required*]
 
 ### SkillType
 

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -8,7 +8,7 @@ import { legsPushData, legsPullData } from './mockData';
 
 const App = () => {
   return (
-    <SkillProvider appId="bst-example">
+    <SkillProvider>
       <SkillTreeGroup>
         {({ skillCount, selectedSkillCount, resetSkills }) => {
           return (
@@ -17,8 +17,16 @@ const App = () => {
                 Completed skills: {selectedSkillCount}/{skillCount}
                 <button onClick={resetSkills}>Reset</button>
               </h2>
-              <SkillTree title="Squat Progression" data={legsPushData} />
-              <SkillTree title="Hinge Progression" data={legsPullData} />
+              <SkillTree
+                treeId="sp"
+                title="Squat Progression"
+                data={legsPushData}
+              />
+              <SkillTree
+                treeId="hp"
+                title="Hinge Progression"
+                data={legsPullData}
+              />
             </React.Fragment>
           );
         }}

--- a/example/mockData.ts
+++ b/example/mockData.ts
@@ -99,6 +99,12 @@ export const legsPushData: Skill[] = [
       },
     ],
   },
+  {
+    id: 'something-else',
+    tooltipDescription: 'burn those leg muscles',
+    title: 'Something Else',
+    children: [],
+  },
 ];
 
 export const legsPullData: Skill[] = [

--- a/package.json
+++ b/package.json
@@ -62,8 +62,10 @@
     "@types/lodash": "^4.14.136",
     "@types/react": "^16.8.23",
     "@types/react-dom": "^16.8.4",
+    "@types/uuid": "^3.4.5",
     "cssnano": "^4.1.10",
     "husky": "^3.0.0",
+    "jest-dom": "^3.5.0",
     "prettier": "^1.18.2",
     "pretty-quick": "^1.11.1",
     "react": "^16.8.6",
@@ -75,7 +77,7 @@
   "dependencies": {
     "@tippy.js/react": "^2.2.2",
     "classnames": "^2.2.6",
-    "jest-dom": "^3.5.0",
-    "lodash": "^4.17.14"
+    "lodash": "^4.17.14",
+    "uuid": "^3.3.2"
   }
 }

--- a/src/__tests__/integeration.test.tsx
+++ b/src/__tests__/integeration.test.tsx
@@ -67,6 +67,12 @@ const complexData: SkillType[] = [
       },
     ],
   },
+  {
+    id: 'paradigms',
+    title: 'OOP',
+    tooltipDescription: 'for objects',
+    children: [],
+  },
 ];
 
 function renderComponent(renderComplexTree = false) {
@@ -294,7 +300,7 @@ describe('SkillTreeGroup component', () => {
       expect(queryByText('Backend')).toBeTruthy();
 
       expect(getByTestId('selected-count')).toHaveTextContent('0');
-      expect(getByTestId('total-count')).toHaveTextContent('9');
+      expect(getByTestId('total-count')).toHaveTextContent('10');
 
       expect(getByTestId('languages')).toHaveClass('Node Node--unlocked');
       expect(getByTestId('python')).toHaveClass('Node Node--locked');

--- a/src/__tests__/integeration.test.tsx
+++ b/src/__tests__/integeration.test.tsx
@@ -71,7 +71,7 @@ const complexData: SkillType[] = [
 
 function renderComponent(renderComplexTree = false) {
   return render(
-    <SkillProvider appId="bst-example">
+    <SkillProvider>
       <SkillTreeGroup>
         {({ skillCount, selectedSkillCount, resetSkills }) => {
           return (
@@ -84,8 +84,9 @@ function renderComponent(renderComplexTree = false) {
                   Reset
                 </button>
               </h2>
-              <SkillTree title="Frontend" data={simpleData} />
+              <SkillTree treeId="fe" title="Frontend" data={simpleData} />
               <SkillTree
+                treeId="be"
                 title="Backend"
                 data={renderComplexTree ? complexData : []}
               />

--- a/src/components/CalculateNodeCount.tsx
+++ b/src/components/CalculateNodeCount.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect } from 'react';
 import { Skill } from 'models';
-import SkillContext from '../context/SkillContext';
+import SkillTreeContext from '../context/SkillTreeContext';
 
 interface Props {
   data: Skill[];
@@ -17,7 +17,7 @@ function calculateNodeCount(data: Skill[]): number {
 }
 
 function CalculateNodeCount({ data }: Props) {
-  const { addToSkillCount } = useContext(SkillContext);
+  const { addToSkillCount } = useContext(SkillTreeContext);
 
   useEffect(() => {
     const count = calculateNodeCount(data);

--- a/src/components/CalculateNodeCount.tsx
+++ b/src/components/CalculateNodeCount.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect } from 'react';
 import { Skill } from 'models';
-import SkillContext from '../context/SkillContext';
+import AppContext from '../context/AppContext';
 
 interface Props {
   data: Skill[];
@@ -17,7 +17,7 @@ function calculateNodeCount(data: Skill[]): number {
 }
 
 function CalculateNodeCount({ data }: Props) {
-  const { addToSkillCount } = useContext(SkillContext);
+  const { addToSkillCount } = useContext(AppContext);
 
   useEffect(() => {
     const count = calculateNodeCount(data);

--- a/src/components/CalculateNodeCount.tsx
+++ b/src/components/CalculateNodeCount.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect } from 'react';
 import { Skill } from 'models';
-import SkillTreeContext from '../context/SkillTreeContext';
+import SkillContext from '../context/SkillContext';
 
 interface Props {
   data: Skill[];
@@ -17,7 +17,7 @@ function calculateNodeCount(data: Skill[]): number {
 }
 
 function CalculateNodeCount({ data }: Props) {
-  const { addToSkillCount } = useContext(SkillTreeContext);
+  const { addToSkillCount } = useContext(SkillContext);
 
   useEffect(() => {
     const count = calculateNodeCount(data);

--- a/src/components/SkillEdge.tsx
+++ b/src/components/SkillEdge.tsx
@@ -4,27 +4,31 @@ import AngledLine from './ui/AngledLine';
 import { NodeState } from 'models';
 
 interface Props {
-  position: {
-    topX: number;
-    topY: number;
-    bottomX: number;
-    bottomY: number;
-  };
+  topX: number;
+  topY: number;
+  bottomX: number;
   nodeState: NodeState;
 }
 
-function SkillEdge({ position, nodeState }: Props) {
-  if (position.topX === position.bottomX) {
-    return <Line {...position} state={nodeState} />;
+const SkillEdge = React.memo(function({
+  topX,
+  topY,
+  bottomX,
+  nodeState,
+}: Props) {
+  if (topX === bottomX) {
+    return <Line topX={topX} topY={topY} state={nodeState} />;
   }
 
   return (
     <AngledLine
-      {...position}
+      topX={topX}
+      topY={topY}
+      bottomX={bottomX}
       state={nodeState}
-      direction={position.topX < position.bottomX ? 'right' : 'left'}
+      direction={topX < bottomX ? 'right' : 'left'}
     />
   );
-}
+});
 
 export default SkillEdge;

--- a/src/components/SkillNode.tsx
+++ b/src/components/SkillNode.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import classnames from 'classnames';
-import { throttle, Cancelable, isEmpty } from 'lodash';
+import { throttle, Cancelable } from 'lodash';
 import Tippy from '@tippy.js/react';
-import SkillContext from '../context/SkillContext';
+import SkillTreeContext from '../context/SkillTreeContext';
 import { LOCKED_STATE, UNLOCKED_STATE, SELECTED_STATE } from './constants';
 import SkillTreeSegment from './SkillTreeSegment';
 import TooltipContent from './ui/TooltipContent';
@@ -19,7 +19,7 @@ interface State {
 }
 
 class SkillNode extends React.Component<Props, State> {
-  static contextType = SkillContext;
+  static contextType = SkillTreeContext;
   private skillNodeRef: React.RefObject<HTMLDivElement>;
   private throttledResize: VoidFunction & Cancelable;
   private childWidth: number = 0;
@@ -90,10 +90,6 @@ class SkillNode extends React.Component<Props, State> {
     this.calculateOverlayWidth();
 
     window.addEventListener('resize', this.throttledResize);
-
-    if (isEmpty(this.context.skills)) {
-      return this.updateState(UNLOCKED_STATE);
-    }
   }
 
   componentWillUnmount() {

--- a/src/components/SkillNode.tsx
+++ b/src/components/SkillNode.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import classnames from 'classnames';
 import { throttle, Cancelable } from 'lodash';
 import Tippy from '@tippy.js/react';
-import SkillTreeContext from '../context/SkillTreeContext';
+import SkillContext from '../context/SkillContext';
 import { LOCKED_STATE, UNLOCKED_STATE, SELECTED_STATE } from './constants';
 import SkillTreeSegment from './SkillTreeSegment';
 import TooltipContent from './ui/TooltipContent';
@@ -20,7 +20,7 @@ interface State {
 }
 
 class SkillNode extends React.Component<Props, State> {
-  static contextType = SkillTreeContext;
+  static contextType = SkillContext;
   private skillNodeRef: React.RefObject<HTMLDivElement>;
   private throttledResize: VoidFunction & Cancelable;
   private childWidth: number = 0;

--- a/src/components/SkillNode.tsx
+++ b/src/components/SkillNode.tsx
@@ -16,6 +16,7 @@ interface Props {
 
 interface State {
   parentPosition: ParentPosition;
+  isMobile: boolean;
 }
 
 class SkillNode extends React.Component<Props, State> {
@@ -31,6 +32,7 @@ class SkillNode extends React.Component<Props, State> {
     this.throttledResize = throttle(this.handleResize, 200);
 
     this.state = {
+      isMobile: window.innerWidth < 900,
       parentPosition: {
         bottom: 0,
         center: 0,
@@ -63,6 +65,10 @@ class SkillNode extends React.Component<Props, State> {
   handleResize = () => {
     this.calculatePosition();
     this.calculateOverlayWidth();
+
+    this.setState(() => ({
+      isMobile: window.innerWidth < 900,
+    }));
   };
 
   handleClick = () => {
@@ -97,7 +103,7 @@ class SkillNode extends React.Component<Props, State> {
   }
 
   render() {
-    const { parentPosition } = this.state;
+    const { parentPosition, isMobile } = this.state;
     const { nodeState, skill } = this.props;
     const { children, title, tooltipDescription, id } = skill;
 
@@ -113,7 +119,7 @@ class SkillNode extends React.Component<Props, State> {
           />
           <Tippy
             className="Tooltip"
-            placement="bottom"
+            placement={isMobile ? 'top' : 'bottom'}
             content={
               <TooltipContent
                 tooltipDescription={tooltipDescription}

--- a/src/components/SkillTree.tsx
+++ b/src/components/SkillTree.tsx
@@ -4,6 +4,7 @@ import { Skill } from '../models';
 import SkillTreeSegment from './SkillTreeSegment';
 import HSeparator from './ui/HSeparator';
 import CalculateTotalNodes from './CalculateNodeCount';
+import { SkillTreeProvider } from '../context/SkillTreeContext';
 
 interface Props {
   data: Skill[];
@@ -31,7 +32,7 @@ function SkillTree({ data, title }: Props) {
   }, []);
 
   return (
-    <React.Fragment>
+    <SkillTreeProvider treeId={title}>
       <CalculateTotalNodes data={data} />
       <div className="SkillTree__container">
         <h2 className="SkillTree__title">{title}</h2>
@@ -50,7 +51,7 @@ function SkillTree({ data, title }: Props) {
           })}
         </div>
       </div>
-    </React.Fragment>
+    </SkillTreeProvider>
   );
 }
 

--- a/src/components/SkillTree.tsx
+++ b/src/components/SkillTree.tsx
@@ -7,6 +7,7 @@ import CalculateTotalNodes from './CalculateNodeCount';
 import { SkillTreeProvider } from '../context/SkillTreeContext';
 
 interface Props {
+  treeId: string;
   data: Skill[];
   title: string;
 }
@@ -16,7 +17,7 @@ const defaultParentPosition = {
   center: 0,
 };
 
-function SkillTree({ data, title }: Props) {
+function SkillTree({ data, title, treeId }: Props) {
   const [isMobile, setIsMobile] = useState(window.innerWidth < 900);
 
   useEffect(() => {
@@ -32,7 +33,7 @@ function SkillTree({ data, title }: Props) {
   }, []);
 
   return (
-    <SkillTreeProvider treeId={title}>
+    <SkillTreeProvider treeId={treeId}>
       <CalculateTotalNodes data={data} />
       <div className="SkillTree__container">
         <h2 className="SkillTree__title">{title}</h2>

--- a/src/components/SkillTree.tsx
+++ b/src/components/SkillTree.tsx
@@ -18,7 +18,7 @@ const defaultParentPosition = {
 };
 
 function SkillTree({ data, title, treeId }: Props) {
-  const [isMobile, setIsMobile] = useState(window.innerWidth < 900);
+  const [isMobile, setIsMobile] = useState(true);
 
   useEffect(() => {
     function setState() {
@@ -26,6 +26,7 @@ function SkillTree({ data, title, treeId }: Props) {
     }
 
     window.addEventListener('resize', throttle(setState, 250));
+    setState();
 
     return function cleanup() {
       window.removeEventListener('resize', throttle(setState, 250));

--- a/src/components/SkillTree.tsx
+++ b/src/components/SkillTree.tsx
@@ -4,7 +4,7 @@ import { Skill } from '../models';
 import SkillTreeSegment from './SkillTreeSegment';
 import HSeparator from './ui/HSeparator';
 import CalculateTotalNodes from './CalculateNodeCount';
-import { SkillTreeProvider } from '../context/SkillTreeContext';
+import { SkillTreeProvider } from '../context/SkillContext';
 
 interface Props {
   treeId: string;

--- a/src/components/SkillTreeGroup.tsx
+++ b/src/components/SkillTreeGroup.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import SkillAppContext from '../context/SkillAppContext';
+import AppContext from '../context/AppContext';
 
 export interface TreeData {
   skillCount: number;
@@ -13,7 +13,7 @@ interface Props {
 
 function SkillTreeGroup(props: Props) {
   const { skillCount, selectedSkillCount, resetSkills } = useContext(
-    SkillAppContext
+    AppContext
   );
 
   const treeData = {

--- a/src/components/SkillTreeGroup.tsx
+++ b/src/components/SkillTreeGroup.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import SkillContext from '../context/SkillContext';
+import SkillAppContext from '../context/SkillAppContext';
 
 export interface TreeData {
   skillCount: number;
@@ -13,7 +13,7 @@ interface Props {
 
 function SkillTreeGroup(props: Props) {
   const { skillCount, selectedSkillCount, resetSkills } = useContext(
-    SkillContext
+    SkillAppContext
   );
 
   const treeData = {

--- a/src/components/SkillTreeSegment.tsx
+++ b/src/components/SkillTreeSegment.tsx
@@ -1,10 +1,10 @@
 import React, { useRef, useEffect, useState, useContext } from 'react';
-import { throttle } from 'lodash';
+import { throttle, isEmpty } from 'lodash';
 import SkillNode from './SkillNode';
 import SkillEdge from './SkillEdge';
 import { Skill, ParentPosition, ChildPosition, NodeState } from '../models';
 import { Nullable } from '../models/utils';
-import SkillContext from '../context/SkillContext';
+import SkillTreeContext from '../context/SkillTreeContext';
 import { SELECTED_STATE, LOCKED_STATE, UNLOCKED_STATE } from './constants';
 
 interface Props {
@@ -27,8 +27,9 @@ const SkillTreeSegment = React.memo(function({
 }: Props) {
   const [childPosition, setChildPosition] = useState(defaultParentPosition);
   const { skills, updateSkillState, decrementSelectedSkillCount } = useContext(
-    SkillContext
+    SkillTreeContext
   );
+
   const skillNodeRef: React.MutableRefObject<Nullable<HTMLDivElement>> = useRef(
     null
   );
@@ -74,6 +75,10 @@ const SkillTreeSegment = React.memo(function({
 
     window.addEventListener('resize', throttle(calculatePosition, 250));
     calculatePosition();
+
+    if (isEmpty(skills)) {
+      return updateSkillState(skill.id, UNLOCKED_STATE);
+    }
 
     return function cleanup() {
       window.removeEventListener('resize', throttle(calculatePosition));

--- a/src/components/SkillTreeSegment.tsx
+++ b/src/components/SkillTreeSegment.tsx
@@ -4,7 +4,7 @@ import SkillNode from './SkillNode';
 import SkillEdge from './SkillEdge';
 import { Skill, ParentPosition, ChildPosition, NodeState } from '../models';
 import { Nullable } from '../models/utils';
-import SkillTreeContext from '../context/SkillTreeContext';
+import SkillContext from '../context/SkillContext';
 import { SELECTED_STATE, LOCKED_STATE, UNLOCKED_STATE } from './constants';
 
 interface Props {
@@ -27,7 +27,7 @@ const SkillTreeSegment = React.memo(function({
 }: Props) {
   const [childPosition, setChildPosition] = useState(defaultParentPosition);
   const { skills, updateSkillState, decrementSelectedSkillCount } = useContext(
-    SkillTreeContext
+    SkillContext
   );
 
   const skillNodeRef: React.MutableRefObject<Nullable<HTMLDivElement>> = useRef(

--- a/src/components/SkillTreeSegment.tsx
+++ b/src/components/SkillTreeSegment.tsx
@@ -15,11 +15,10 @@ interface Props {
 }
 
 const defaultParentPosition: ChildPosition = {
-  top: 0,
   center: 0,
 };
 
-const SkillTreeSegment = React.memo(function({
+function SkillTreeSegment({
   skill,
   parentNodeId,
   parentPosition,
@@ -58,17 +57,11 @@ const SkillTreeSegment = React.memo(function({
 
   useEffect(() => {
     function calculatePosition() {
-      const {
-        top,
-        left,
-        width,
-      } = skillNodeRef.current!.getBoundingClientRect();
+      const { left, width } = skillNodeRef.current!.getBoundingClientRect();
 
-      const scrollY = window.scrollY;
       const scrollX = window.scrollX;
 
       setChildPosition({
-        top: top + scrollY,
         center: left + width / 2 + scrollX,
       });
     }
@@ -90,12 +83,9 @@ const SkillTreeSegment = React.memo(function({
       {parentNodeId && (
         <SkillEdge
           nodeState={nodeState}
-          position={{
-            topX: parentPosition.center,
-            topY: parentPosition.bottom,
-            bottomX: childPosition.center,
-            bottomY: childPosition.top,
-          }}
+          topX={parentPosition.center}
+          topY={parentPosition.bottom}
+          bottomX={childPosition.center}
         />
       )}
       <div ref={skillNodeRef}>
@@ -103,6 +93,6 @@ const SkillTreeSegment = React.memo(function({
       </div>
     </div>
   );
-});
+}
 
 export default SkillTreeSegment;

--- a/src/components/__tests__/CalculateNodeCount.test.tsx
+++ b/src/components/__tests__/CalculateNodeCount.test.tsx
@@ -2,7 +2,8 @@ import React, { useContext } from 'react';
 import { render } from '@testing-library/react';
 import CalculateSkillNodes from '../CalculateNodeCount';
 import { Skill } from 'models';
-import SkillContext from '../../context/SkillContext';
+import SkillAppContext from '../../context/SkillAppContext';
+import { SkillTreeProvider } from '../../context/SkillTreeContext';
 import {
   legsPullData,
   legsPushData,
@@ -13,7 +14,7 @@ interface GetDummyCounterProps {
 }
 
 function GetDummyCounter({ children }: GetDummyCounterProps) {
-  const { skillCount } = useContext(SkillContext);
+  const { skillCount } = useContext(SkillAppContext);
 
   return children(skillCount);
 }
@@ -29,7 +30,11 @@ function renderComponent(data: Skill[]) {
     <GetDummyCounter>
       {skillCount => {
         counter = skillCount;
-        return <CalculateSkillNodes data={data} />;
+        return (
+          <SkillTreeProvider treeId="hey">
+            <CalculateSkillNodes data={data} />>
+          </SkillTreeProvider>
+        );
       }}
     </GetDummyCounter>
   );
@@ -47,14 +52,14 @@ describe('CalculateSkillNodes component', () => {
     expect(getCounter).toBe(0);
   });
 
-  xit('should correctly calculate a single branch tree', async () => {
+  it('should correctly calculate a single branch tree', async () => {
     const { getCounter, debug } = renderComponent(legsPullData);
     debug();
 
     expect(getCounter).toBe(6);
   });
 
-  xit('should correctly calculate a tree with multiples branches', () => {
+  it('should correctly calculate a tree with multiples branches', () => {
     const { getCounter } = renderComponent(legsPushData);
 
     expect(getCounter).toBe(6);

--- a/src/components/__tests__/CalculateNodeCount.test.tsx
+++ b/src/components/__tests__/CalculateNodeCount.test.tsx
@@ -1,13 +1,9 @@
 import React, { useContext } from 'react';
 import { render } from '@testing-library/react';
 import CalculateSkillNodes from '../CalculateNodeCount';
-import { Skill } from 'models';
+import { Skill } from '../../models';
 import AppContext from '../../context/AppContext';
 import { SkillTreeProvider } from '../../context/SkillContext';
-import {
-  legsPullData,
-  legsPushData,
-} from '../../components/__mocks__/mockData';
 
 interface GetDummyCounterProps {
   children: (skillCount: number) => JSX.Element;
@@ -50,18 +46,5 @@ describe('CalculateSkillNodes component', () => {
     const { getCounter } = renderComponent([]);
 
     expect(getCounter).toBe(0);
-  });
-
-  it('should correctly calculate a single branch tree', async () => {
-    const { getCounter, debug } = renderComponent(legsPullData);
-    debug();
-
-    expect(getCounter).toBe(6);
-  });
-
-  it('should correctly calculate a tree with multiples branches', () => {
-    const { getCounter } = renderComponent(legsPushData);
-
-    expect(getCounter).toBe(6);
   });
 });

--- a/src/components/__tests__/CalculateNodeCount.test.tsx
+++ b/src/components/__tests__/CalculateNodeCount.test.tsx
@@ -2,8 +2,8 @@ import React, { useContext } from 'react';
 import { render } from '@testing-library/react';
 import CalculateSkillNodes from '../CalculateNodeCount';
 import { Skill } from 'models';
-import SkillAppContext from '../../context/SkillAppContext';
-import { SkillTreeProvider } from '../../context/SkillTreeContext';
+import AppContext from '../../context/AppContext';
+import { SkillTreeProvider } from '../../context/SkillContext';
 import {
   legsPullData,
   legsPushData,
@@ -14,7 +14,7 @@ interface GetDummyCounterProps {
 }
 
 function GetDummyCounter({ children }: GetDummyCounterProps) {
-  const { skillCount } = useContext(SkillAppContext);
+  const { skillCount } = useContext(AppContext);
 
   return children(skillCount);
 }

--- a/src/components/__tests__/SkillEdge.test.tsx
+++ b/src/components/__tests__/SkillEdge.test.tsx
@@ -7,13 +7,15 @@ const defaultPosition = {
   topX: 0,
   topY: 0,
   bottomX: 0,
-  bottomY: 0,
 };
 
 function renderComponent(startingState: NodeState, position = defaultPosition) {
   let state = startingState;
+  const { topX, topY, bottomX } = position;
 
-  return render(<SkillEdge nodeState={state} position={position} />);
+  return render(
+    <SkillEdge nodeState={state} topX={topX} topY={topY} bottomX={bottomX} />
+  );
 }
 
 describe('SkillEdge', () => {
@@ -56,14 +58,12 @@ describe('SkillEdge', () => {
       topX: 100,
       topY: 100,
       bottomX: 50,
-      bottomY: 150,
     };
 
     const rightAngledLinePosition = {
       topX: 100,
       topY: 100,
       bottomX: 150,
-      bottomY: 150,
     };
 
     it('should be inactive if the next node is unlocked', async () => {

--- a/src/components/__tests__/SkillNode.test.tsx
+++ b/src/components/__tests__/SkillNode.test.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
-import { render, act, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import SkillNode from '../SkillNode';
 import { NodeState } from 'models';
-
-function fireResize(width: number) {
-  // @ts-ignore
-  window.innerWidth = width;
-  window.dispatchEvent(new Event('resize'));
-}
 
 function renderComponent(nodeState: NodeState = 'locked') {
   return render(
@@ -48,15 +42,11 @@ describe('SkillNode component', () => {
   });
 
   it('should handle resizing of the window correctly', () => {
-    const resizeEvent = document.createEvent('Event');
-    resizeEvent.initEvent('resize', true, true);
+    // @ts-ignore
+    window.innerWidth = 200;
 
     renderComponent();
 
-    // empty until i can work out how to attach the renderedComponnet to the DOM
-    // otherwise getBoundingClientRect() always returns 0.
-    act(() => {
-      fireResize(400);
-    });
+    // check that hr exists
   });
 });

--- a/src/components/__tests__/SkillTree.test.tsx
+++ b/src/components/__tests__/SkillTree.test.tsx
@@ -4,7 +4,6 @@ import SkillTree from '../SkillTree';
 import MockLocalStorage from '../__mocks__/mockLocalStorage';
 import { SkillProvider } from '../../context/AppContext';
 import SkillTreeGroup from '../../components/SkillTreeGroup';
-import { SkillTreeProvider } from '../../context/SkillContext';
 
 const mockSkillTreeData = [
   {
@@ -42,10 +41,8 @@ const mockSkillTreeData = [
 ];
 
 const defaultStoreContents = {
-  [`skills-test`]: JSON.stringify({}),
+  [`skills-bl`]: JSON.stringify({}),
 };
-
-const storage = new MockLocalStorage(defaultStoreContents);
 
 function renderComponent() {
   let selectedSkillCount: number;
@@ -58,13 +55,11 @@ function renderComponent() {
           selectedSkillCount = treeData.selectedSkillCount;
           resetSkills = treeData.resetSkills;
           return (
-            <SkillTreeProvider treeId="hey">
-              <SkillTree
-                treeId="bl"
-                title="borderlands"
-                data={mockSkillTreeData}
-              />
-            </SkillTreeProvider>
+            <SkillTree
+              treeId="bl"
+              title="borderlands"
+              data={mockSkillTreeData}
+            />
           );
         }}
       </SkillTreeGroup>
@@ -82,14 +77,13 @@ function renderComponent() {
   };
 }
 
-function fireResize(width: number) {
-  // @ts-ignore
-  window.innerWidth = width;
-  window.dispatchEvent(new Event('resize'));
-}
-
 afterEach(() => {
-  storage.setItem('skills-test', JSON.stringify({}));
+  window.localStorage.setItem('skills-bl', JSON.stringify({}));
+});
+
+beforeEach(() => {
+  //@ts-ignore
+  window.localStorage = new MockLocalStorage(defaultStoreContents);
 });
 
 describe('SkillTree', () => {
@@ -168,7 +162,7 @@ describe('SkillTree', () => {
       'item-three': 'locked',
     };
 
-    storage.setItem(`skills-test`, JSON.stringify(defaultSkills));
+    window.localStorage.setItem(`skills-bl`, JSON.stringify(defaultSkills));
 
     const { getByTestId, getSelectedSkillCount } = renderComponent();
 
@@ -183,7 +177,7 @@ describe('SkillTree', () => {
     expect(getSelectedSkillCount()).toBe(1);
   });
 
-  xit('should deselect all skill trees when resetSkills is invoked', () => {
+  it('should deselect all skill trees when resetSkills is invoked', () => {
     const {
       getByTestId,
       getSelectedSkillCount,
@@ -206,7 +200,7 @@ describe('SkillTree', () => {
 
     resetSkillsHandler();
 
-    expect(topNode).toHaveClass('Node Node--unlocked');
+    expect(topNode).toHaveClass('Node Node--locked');
     expect(middleNode).toHaveClass('Node Node--locked');
     expect(bottomNode).toHaveClass('Node Node--locked');
 
@@ -222,21 +216,29 @@ describe('SkillTree', () => {
     expect(queryByTestId('h-separator')).toBeTruthy();
   });
 
-  xit('should correctly handle resizing from desktop to mobile', () => {
-    const resizeEvent = document.createEvent('Event');
+  xdescribe('resizing', () => {
+    function fireResize(width: number) {
+      // @ts-ignore
+      window.innerWidth = width;
+      window.dispatchEvent(new Event('resize'));
+    }
 
-    // @ts-ignore
-    window.innerWidth = 1000;
-    resizeEvent.initEvent('resize', false, false);
+    it('should handle resizing from desktop to mobile', () => {
+      const resizeEvent = document.createEvent('Event');
 
-    const { queryByTestId } = renderComponent();
+      // @ts-ignore
+      window.innerWidth = 1000;
+      resizeEvent.initEvent('resize', true, true);
 
-    expect(queryByTestId('h-separator')).toBeFalsy();
+      const { queryByTestId } = renderComponent();
 
-    act(() => {
-      fireResize(400);
+      expect(queryByTestId('h-separator')).toBeFalsy();
+
+      act(() => {
+        fireResize(400);
+      });
+
+      expect(queryByTestId('h-separator')).toBeTruthy();
     });
-
-    expect(queryByTestId('h-separator')).toBeTruthy();
   });
 });

--- a/src/components/__tests__/SkillTree.test.tsx
+++ b/src/components/__tests__/SkillTree.test.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react';
 import SkillTree from '../SkillTree';
 import MockLocalStorage from '../__mocks__/mockLocalStorage';
-import { SkillProvider } from '../../context/SkillAppContext';
+import { SkillProvider } from '../../context/AppContext';
 import SkillTreeGroup from '../../components/SkillTreeGroup';
-import { SkillTreeProvider } from '../../context/SkillTreeContext';
+import { SkillTreeProvider } from '../../context/SkillContext';
 
 const mockSkillTreeData = [
   {

--- a/src/components/__tests__/SkillTree.test.tsx
+++ b/src/components/__tests__/SkillTree.test.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react';
 import SkillTree from '../SkillTree';
 import MockLocalStorage from '../__mocks__/mockLocalStorage';
-import { SkillProvider } from '../../context/SkillContext';
+import { SkillProvider } from '../../context/SkillAppContext';
 import SkillTreeGroup from '../../components/SkillTreeGroup';
+import { SkillTreeProvider } from '../../context/SkillTreeContext';
 
 const mockSkillTreeData = [
   {
@@ -56,7 +57,11 @@ function renderComponent() {
         {treeData => {
           selectedSkillCount = treeData.selectedSkillCount;
           resetSkills = treeData.resetSkills;
-          return <SkillTree title="borderlands" data={mockSkillTreeData} />;
+          return (
+            <SkillTreeProvider treeId="hey">
+              <SkillTree title="borderlands" data={mockSkillTreeData} />
+            </SkillTreeProvider>
+          );
         }}
       </SkillTreeGroup>
     </SkillProvider>

--- a/src/components/__tests__/SkillTree.test.tsx
+++ b/src/components/__tests__/SkillTree.test.tsx
@@ -52,14 +52,18 @@ function renderComponent() {
   let resetSkills: VoidFunction;
 
   const api = render(
-    <SkillProvider appId="test" storage={storage}>
+    <SkillProvider>
       <SkillTreeGroup>
         {treeData => {
           selectedSkillCount = treeData.selectedSkillCount;
           resetSkills = treeData.resetSkills;
           return (
             <SkillTreeProvider treeId="hey">
-              <SkillTree title="borderlands" data={mockSkillTreeData} />
+              <SkillTree
+                treeId="bl"
+                title="borderlands"
+                data={mockSkillTreeData}
+              />
             </SkillTreeProvider>
           );
         }}

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -6,7 +6,7 @@ export interface Props {
   title: string;
 }
 
-function Icon({ src, title, containerWidth }: Props) {
+const Icon = React.memo(function({ src, title, containerWidth }: Props) {
   return (
     <div
       data-testid="icon-container"
@@ -24,6 +24,6 @@ function Icon({ src, title, containerWidth }: Props) {
       />
     </div>
   );
-}
+});
 
 export default Icon;

--- a/src/components/ui/TooltipContent.tsx
+++ b/src/components/ui/TooltipContent.tsx
@@ -5,13 +5,16 @@ type Props = {
   title: string;
 };
 
-function TooltipContent({ tooltipDescription, title }: Props) {
+const TooltipContent = React.memo(function({
+  tooltipDescription,
+  title,
+}: Props) {
   return (
     <React.Fragment>
       <h1 className="TooltipContent__title">{title}</h1>
       <p>{tooltipDescription}</p>
     </React.Fragment>
   );
-}
+});
 
 export default TooltipContent;

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -5,7 +5,7 @@ interface State {
   selectedSkillCount: number;
 }
 
-export interface ISkillAppContext {
+export interface IAppContext {
   skillCount: number;
   selectedSkillCount: number;
   incrementSelectedSkillCount: (number: number) => void;
@@ -14,7 +14,7 @@ export interface ISkillAppContext {
   resetSkills: VoidFunction;
 }
 
-const SkillAppContext = React.createContext<ISkillAppContext>({
+const AppContext = React.createContext<IAppContext>({
   skillCount: 0,
   selectedSkillCount: 0,
   incrementSelectedSkillCount: () => undefined,
@@ -72,7 +72,7 @@ export class SkillProvider extends React.Component<{}, State> {
 
   render() {
     return (
-      <SkillAppContext.Provider
+      <AppContext.Provider
         value={{
           addToSkillCount: this.addToSkillCount,
           skillCount: this.state.skillCount,
@@ -83,9 +83,9 @@ export class SkillProvider extends React.Component<{}, State> {
         }}
       >
         {this.props.children}
-      </SkillAppContext.Provider>
+      </AppContext.Provider>
     );
   }
 }
 
-export default SkillAppContext;
+export default AppContext;

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,20 +1,24 @@
 import * as React from 'react';
+import uuid from 'uuid';
 
 interface State {
+  resetId: string;
   skillCount: number;
   selectedSkillCount: number;
 }
 
 export interface IAppContext {
+  resetId: string;
   skillCount: number;
   selectedSkillCount: number;
-  incrementSelectedSkillCount: (number: number) => void;
   decrementSelectedSkillCount: VoidFunction;
-  addToSkillCount: (number: number) => void;
   resetSkills: VoidFunction;
+  incrementSelectedSkillCount: (number: number) => void;
+  addToSkillCount: (number: number) => void;
 }
 
 const AppContext = React.createContext<IAppContext>({
+  resetId: '',
   skillCount: 0,
   selectedSkillCount: 0,
   incrementSelectedSkillCount: () => undefined,
@@ -25,8 +29,9 @@ const AppContext = React.createContext<IAppContext>({
 
 export class SkillProvider extends React.Component<{}, State> {
   state = {
-    selectedSkillCount: 0,
+    resetId: '',
     skillCount: 0,
+    selectedSkillCount: 0,
   };
 
   // refactor the increment items to use just one method.
@@ -53,21 +58,10 @@ export class SkillProvider extends React.Component<{}, State> {
   };
 
   resetSkills = () => {
-    // return this.setState(prevState => {
-    //   const { globalSkills } = prevState;
-    //   let skillTrees: Dictionary<Skills> = {};
-    //   Object.keys(globalSkills).map(key => {
-    //     const resettedValues = mapValues(
-    //       globalSkills[key],
-    //       (): NodeState => LOCKED_STATE
-    //     );
-    //     skillTrees[key] = resettedValues;
-    //   });
-    //   return {
-    //     globalSkills: skillTrees,
-    //     selectedSkillCount: 0,
-    //   };
-    // });
+    this.setState({
+      resetId: uuid(),
+      selectedSkillCount: 0,
+    });
   };
 
   render() {
@@ -80,6 +74,7 @@ export class SkillProvider extends React.Component<{}, State> {
           decrementSelectedSkillCount: this.decrementSelectedSkillCount,
           selectedSkillCount: this.state.selectedSkillCount,
           resetSkills: this.resetSkills,
+          resetId: this.state.resetId,
         }}
       >
         {this.props.children}

--- a/src/context/SkillAppContext.tsx
+++ b/src/context/SkillAppContext.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import { mapValues } from 'lodash';
 import { ContextStorage, NodeState } from '../models';
 import { Dictionary } from '../models/utils';
-// import { SELECTED_STATE } from '../components/constants';
+import { LOCKED_STATE } from '../components/constants';
 
 type Props = typeof SkillProvider.defaultProps & {
   appId: string;
@@ -99,18 +100,24 @@ export class SkillProvider extends React.Component<Props, State> {
   };
 
   resetSkills = () => {
-    // return this.setState(prevState => {
-    //   const { globalSkills } = prevState;
-    //   let resettedSkills = { ...globalSkills };
-    //   const skillKeys = Object.keys(resettedSkills);
-    //   skillKeys.map(key => {
-    //     resettedSkills[key] = 'locked';
-    //   });
-    //   return {
-    //     skills: resettedSkills,
-    //     selectedSkillCount: 0,
-    //   };
-    // });
+    return this.setState(prevState => {
+      const { globalSkills } = prevState;
+      let skillTrees: Dictionary<Skills> = {};
+
+      Object.keys(globalSkills).map(key => {
+        const resettedValues = mapValues(
+          globalSkills[key],
+          (): NodeState => LOCKED_STATE
+        );
+
+        skillTrees[key] = resettedValues;
+      });
+
+      return {
+        globalSkills: skillTrees,
+        selectedSkillCount: 0,
+      };
+    });
   };
 
   updateSkillState = (treeId: string, updatedState: Skills): void => {

--- a/src/context/SkillAppContext.tsx
+++ b/src/context/SkillAppContext.tsx
@@ -1,74 +1,33 @@
 import * as React from 'react';
-import { mapValues } from 'lodash';
-import { ContextStorage, NodeState } from '../models';
-import { Dictionary } from '../models/utils';
-import { LOCKED_STATE } from '../components/constants';
-
-type Props = typeof SkillProvider.defaultProps & {
-  appId: string;
-};
-
-type DefaultProps = {
-  storage: ContextStorage;
-};
-
-type Skills = Dictionary<NodeState>;
 
 interface State {
-  globalSkills: Dictionary<Skills>;
   skillCount: number;
   selectedSkillCount: number;
 }
 
 export interface ISkillAppContext {
-  appId: string;
   skillCount: number;
   selectedSkillCount: number;
-  updateSkillState: (treeId: string, updatedState: Skills) => void;
-  incrementSelectedSkillCount: VoidFunction;
+  incrementSelectedSkillCount: (number: number) => void;
   decrementSelectedSkillCount: VoidFunction;
   addToSkillCount: (number: number) => void;
-  addToSelectedSkillCount: (number: number) => void;
   resetSkills: VoidFunction;
 }
 
 const SkillAppContext = React.createContext<ISkillAppContext>({
-  appId: '',
   skillCount: 0,
   selectedSkillCount: 0,
-  updateSkillState: () => undefined,
   incrementSelectedSkillCount: () => undefined,
   decrementSelectedSkillCount: () => undefined,
   addToSkillCount: () => undefined,
-  addToSelectedSkillCount: () => undefined,
   resetSkills: () => undefined,
 });
 
-export class SkillProvider extends React.Component<Props, State> {
-  static defaultProps: DefaultProps = {
-    storage: localStorage,
+export class SkillProvider extends React.Component<{}, State> {
+  state = {
+    selectedSkillCount: 0,
+    skillCount: 0,
   };
-
-  constructor(props: Props) {
-    super(props);
-
-    const storedSkills: Dictionary<Skills> =
-      JSON.parse(props.storage.getItem(`skills-${props.appId}`)!) || {};
-
-    this.state = {
-      selectedSkillCount: 0,
-      globalSkills: storedSkills,
-      skillCount: 0,
-    };
-  }
-
-  componentDidMount() {
-    window.addEventListener('beforeunload', this.writeToStorage);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('beforeunload', this.writeToStorage);
-  }
 
   // refactor the increment items to use just one method.
   addToSkillCount = (number: number): void => {
@@ -77,16 +36,10 @@ export class SkillProvider extends React.Component<Props, State> {
     }));
   };
 
-  addToSelectedSkillCount = (number: number): void => {
-    this.setState(({ selectedSkillCount }) => ({
-      selectedSkillCount: selectedSkillCount + number,
-    }));
-  };
-
-  incrementSelectedSkillCount = (): void => {
+  incrementSelectedSkillCount = (number: number = 1): void => {
     return this.setState(({ selectedSkillCount }) => {
       return {
-        selectedSkillCount: selectedSkillCount + 1,
+        selectedSkillCount: selectedSkillCount + number,
       };
     });
   };
@@ -100,54 +53,28 @@ export class SkillProvider extends React.Component<Props, State> {
   };
 
   resetSkills = () => {
-    return this.setState(prevState => {
-      const { globalSkills } = prevState;
-      let skillTrees: Dictionary<Skills> = {};
-
-      Object.keys(globalSkills).map(key => {
-        const resettedValues = mapValues(
-          globalSkills[key],
-          (): NodeState => LOCKED_STATE
-        );
-
-        skillTrees[key] = resettedValues;
-      });
-
-      return {
-        globalSkills: skillTrees,
-        selectedSkillCount: 0,
-      };
-    });
-  };
-
-  updateSkillState = (treeId: string, updatedState: Skills): void => {
-    this.setState((prevState: State) => {
-      const updatedSkills = {
-        ...prevState.globalSkills,
-        [treeId]: updatedState,
-      };
-
-      return {
-        globalSkills: updatedSkills,
-      };
-    });
-  };
-
-  writeToStorage = () => {
-    this.props.storage.setItem(
-      `skills-${this.props.appId}`,
-      JSON.stringify(this.state.globalSkills)
-    );
+    // return this.setState(prevState => {
+    //   const { globalSkills } = prevState;
+    //   let skillTrees: Dictionary<Skills> = {};
+    //   Object.keys(globalSkills).map(key => {
+    //     const resettedValues = mapValues(
+    //       globalSkills[key],
+    //       (): NodeState => LOCKED_STATE
+    //     );
+    //     skillTrees[key] = resettedValues;
+    //   });
+    //   return {
+    //     globalSkills: skillTrees,
+    //     selectedSkillCount: 0,
+    //   };
+    // });
   };
 
   render() {
     return (
       <SkillAppContext.Provider
         value={{
-          appId: this.props.appId,
-          updateSkillState: this.updateSkillState,
           addToSkillCount: this.addToSkillCount,
-          addToSelectedSkillCount: this.addToSelectedSkillCount,
           skillCount: this.state.skillCount,
           incrementSelectedSkillCount: this.incrementSelectedSkillCount,
           decrementSelectedSkillCount: this.decrementSelectedSkillCount,

--- a/src/context/SkillContext.tsx
+++ b/src/context/SkillContext.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { NodeState, ContextStorage } from '../models';
 import { Dictionary } from '../models/utils';
-import SkillAppContext, { ISkillAppContext } from './SkillAppContext';
+import AppContext, { IAppContext } from './AppContext';
 import { SELECTED_STATE } from '../components/constants';
 
 type Props = typeof SkillTreeProvider.defaultProps & {
@@ -18,7 +18,7 @@ interface State {
   skills: Skills;
 }
 
-export interface ISkillTreeContext {
+export interface ISkillContext {
   skills: Skills;
   updateSkillState: (key: string, updatedState: NodeState) => void;
   incrementSelectedSkillCount: VoidFunction;
@@ -26,7 +26,7 @@ export interface ISkillTreeContext {
   addToSkillCount: (count: number) => void;
 }
 
-const SkillTreeContext = React.createContext<ISkillTreeContext>({
+const SkillContext = React.createContext<ISkillContext>({
   skills: {},
   updateSkillState: () => undefined,
   incrementSelectedSkillCount: () => undefined,
@@ -35,12 +35,12 @@ const SkillTreeContext = React.createContext<ISkillTreeContext>({
 });
 
 export class SkillTreeProvider extends React.Component<Props, State> {
-  static contextType = SkillAppContext;
+  static contextType = AppContext;
   static defaultProps: DefaultProps = {
     storage: localStorage,
   };
 
-  constructor(props: Props, context: ISkillAppContext) {
+  constructor(props: Props, context: IAppContext) {
     super(props, context);
 
     const treeSkills: Skills =
@@ -95,7 +95,7 @@ export class SkillTreeProvider extends React.Component<Props, State> {
 
   render() {
     return (
-      <SkillTreeContext.Provider
+      <SkillContext.Provider
         value={{
           skills: this.state.skills,
           updateSkillState: this.updateSkillState,
@@ -105,9 +105,9 @@ export class SkillTreeProvider extends React.Component<Props, State> {
         }}
       >
         {this.props.children}
-      </SkillTreeContext.Provider>
+      </SkillContext.Provider>
     );
   }
 }
 
-export default SkillTreeContext;
+export default SkillContext;

--- a/src/context/SkillTreeContext.tsx
+++ b/src/context/SkillTreeContext.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { isEmpty } from 'lodash';
+import { NodeState, ContextStorage } from '../models';
+import { Dictionary } from '../models/utils';
+import SkillAppContext, {
+  SkillProvider,
+  ISkillAppContext,
+} from './SkillAppContext';
+import { SELECTED_STATE } from '../components/constants';
+
+type Props = typeof SkillProvider.defaultProps & {
+  treeId: string;
+};
+
+type DefaultProps = {
+  storage: ContextStorage;
+};
+
+type Skills = Dictionary<NodeState>;
+
+interface State {
+  skills: Skills;
+}
+
+export interface ISkillTreeContext {
+  skills: Skills;
+  updateSkillState: (key: string, updatedState: NodeState) => void;
+  incrementSelectedSkillCount: VoidFunction;
+  decrementSelectedSkillCount: VoidFunction;
+  addToSkillCount: (count: number) => void;
+}
+
+const SkillTreeContext = React.createContext<ISkillTreeContext>({
+  skills: {},
+  updateSkillState: () => undefined,
+  incrementSelectedSkillCount: () => undefined,
+  decrementSelectedSkillCount: () => undefined,
+  addToSkillCount: () => undefined,
+});
+
+export class SkillTreeProvider extends React.Component<Props, State> {
+  static contextType = SkillAppContext;
+  static defaultProps: DefaultProps = {
+    storage: localStorage,
+  };
+
+  constructor(props: Props, context: ISkillAppContext) {
+    super(props, context);
+
+    const allStoredSkills: Dictionary<Skills> =
+      JSON.parse(props.storage.getItem(`skills-${context.appId}`)!) || {};
+
+    if (isEmpty(allStoredSkills)) {
+    }
+
+    const treeSkills = allStoredSkills[props.treeId] || {};
+    const selectedSkillCount = Object.keys(treeSkills).reduce((acc, i) => {
+      if (treeSkills[i] === SELECTED_STATE) {
+        return acc + 1;
+      }
+
+      return acc;
+    }, 0);
+
+    context.addToSelectedSkillCount(selectedSkillCount);
+
+    this.state = {
+      skills: treeSkills,
+    };
+  }
+
+  addToSkillCount = (count: number) => {
+    return this.context.addToSkillCount(count);
+  };
+
+  updateSkillState = (key: string, updatedState: NodeState) => {
+    return this.setState(prevState => {
+      const updatedSkills = {
+        ...prevState.skills,
+        [key]: updatedState,
+      };
+
+      this.context.updateSkillState(this.props.treeId, updatedSkills);
+
+      return {
+        skills: updatedSkills,
+      };
+    });
+  };
+
+  render() {
+    return (
+      <SkillTreeContext.Provider
+        value={{
+          skills: this.state.skills,
+          updateSkillState: this.updateSkillState,
+          incrementSelectedSkillCount: this.context.incrementSelectedSkillCount,
+          decrementSelectedSkillCount: this.context.decrementSelectedSkillCount,
+          addToSkillCount: this.addToSkillCount,
+        }}
+      >
+        {this.props.children}
+      </SkillTreeContext.Provider>
+    );
+  }
+}
+
+export default SkillTreeContext;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
 export { default as SkillTreeGroup } from './components/SkillTreeGroup';
 export { default as SkillTree } from './components/SkillTree';
-export { SkillProvider } from './context/SkillAppContext';
+export { SkillProvider } from './context/AppContext';
 export { Skill as SkillType } from './models/index';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
 export { default as SkillTreeGroup } from './components/SkillTreeGroup';
 export { default as SkillTree } from './components/SkillTree';
-export { SkillProvider } from './context/SkillContext';
+export { SkillProvider } from './context/SkillAppContext';
 export { Skill as SkillType } from './models/index';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -25,7 +25,6 @@ export type ParentPosition = {
 };
 
 export type ChildPosition = {
-  top: number;
   center: number;
 };
 


### PR DESCRIPTION
Global state was getting complex and convoluted. 

Attempting to move out the global skill store, to one that's scoped to each individual skill tree. 